### PR TITLE
docs(ORCH-0003): define minimal MVP labels and manual review rule

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -340,4 +340,21 @@ Steps to validate:
 4. Confirm the PR template is populated.
 5. Confirm the PR description links back to the task when the issue number is available.
 
-This is a documentation-only validation step for the MVP workflow.
+This is a documentation-only validation step for the MVP workflow.## 9. Minimum MVP labels and manual review rule
+
+### Minimum MVP label set
+- status/todo
+- status/in-progress
+- status/review
+- status/done
+- assigned/cursor
+- assigned/openai
+- assigned/human
+- orchestration/task-spec
+
+### Minimum manual PR review rule
+A PR can be approved only after a human reviewer confirms:
+- the PR addresses the issue’s Success Criteria,
+- stated risks/assumptions are reflected in the PR description,
+- no unexpected changes were made outside the task scope,
+- the PR uses the agreed template sections.


### PR DESCRIPTION
## Task
- **Task ID:** ORCH-0003
- **Links:** Fixes #4

## Summary
This PR adds an explicit MVP baseline to `docs/WORKFLOW.md`:
- A clearly defined **minimum label set** for MVP operation.
- A clearly defined **minimum manual PR review rule** that gate-keeps human approval.

No MCP, webhooks, GitHub Actions, or advanced automation are introduced—this is documentation-only.

## How to verify
- Open `docs/WORKFLOW.md`
- Confirm it includes:
  - the “Minimum MVP label set” section with exactly the 8 labels listed in ORCH-0003,
  - the “Minimum manual PR review rule” section with the human approval conditions.

## Files / areas touched
| Path | Why |
|------|-----|
| `docs/WORKFLOW.md` | Adds the minimum label set + minimum manual review rule |

## Risks & assumptions
- Assumes the repo continues to use the PR template sections referenced by the review rule.

## Follow-ups
- After this is merged, you can standardize label usage in GitHub UI to match the documented minimum set.

## Checklist
- [ ] Documentation updated
- [ ] MVP-only change (docs-only)
