### PR TITLE
docs(ORCH-0005): define MVP branch protection and merge hygiene

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -357,4 +357,11 @@ A PR can be approved only after a human reviewer confirms:
 - the PR addresses the issue’s Success Criteria,
 - stated risks/assumptions are reflected in the PR description,
 - no unexpected changes were made outside the task scope,
-- the PR uses the agreed template sections.
+- the PR uses the agreed template sections.## 10. MVP branch protection and merge hygiene
+
+For MVP operation:
+
+- Never create commits directly on `main` for task work.
+- All task work must be delivered through a pull request.
+- No pull request should be merged without human review/approval.
+- A pull request should be merged only when the issue’s Success Criteria and Definition of Done are satisfied.


### PR DESCRIPTION
## Task
- **Task ID:** ORCH-0005
- **Links:** Fixes #7

## Summary
This PR adds a minimal documentation section to `docs/WORKFLOW.md` that defines the MVP merge hygiene rules:
- no direct commits/work on `main`
- all changes delivered via pull requests
- human review/approval required before merge
- merges allowed only when the issue’s Success Criteria / Definition of Done are satisfied

No GitHub Actions, webhooks, MCP, or advanced automation are introduced.

### What Changed
- Added an “MVP branch protection and merge hygiene” section to `docs/WORKFLOW.md`

### How to Test
1. Open `docs/WORKFLOW.md`
2. Confirm the section **“MVP branch protection and merge hygiene”** exists
3. Confirm it includes:
   - Never create commits directly on `main` for task work
   - All task work delivered via a pull request
   - No merge without human review/approval
   - PR merges only when Success Criteria and Definition of Done are satisfied

### Validation Checklist
- [x] Documentation change matches ORCH-0005
- [x] No automation/webhook/MCP content added
- [x] MVP-only scope maintained
