### PR TITLE
docs(ORCH-0006): align MVP documentation across README, WORKFLOW and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,121 +1,32 @@
 # Contributing to AI Orchestrator
 
-Welcome to AI Orchestrator! This document explains how to participate in our GitHub-based development workflow.
+## MVP workflow
 
-## Quick Start
+This repository uses a manual MVP workflow:
 
-Before contributing, please read:
-1. [SYSTEM_ROLES.md](SYSTEM_ROLES.md) — Understand your role and boundaries
-2. [docs/WORKFLOW.md](docs/WORKFLOW.md) — Learn the task lifecycle
-3. [docs/ORCHESTRATION.md](docs/ORCHESTRATION.md) — Understand the architecture
+1. OpenAI / ChatGPT writes task specifications in GitHub Issues
+2. Work is done on a task branch
+3. Changes are delivered through a pull request
+4. A human reviews and merges the pull request
 
-## The MVP Workflow
+## Current MVP roles
 
-### If You're the OpenAI/ChatGPT Director
-1. Analyze work that needs to be done
-2. Break it into discrete tasks
-3. Create a GitHub Issue using the **Task Spec** template
-4. Include clear success criteria and context
-5. Respond to Cursor's clarifying questions in issue comments
-6. Review PRs and provide feedback
+- **GitHub** is the source of truth
+- **OpenAI / ChatGPT** is the director and task spec author
+- **Cursor** is the executor
+- **Base44** is used for visualization and drafting only
+- **Humans** review and approve merges
 
-### If You're a Cursor/Coding Specialist
-1. Watch for issues labeled `assigned/cursor` with `status/todo`
-2. Read the task spec completely in the Issue
-3. Ask clarifying questions in comments if needed
-4. `git checkout feature/task-{id}-{slug}`
-5. Implement code changes
-6. Commit with message: `git commit -m "feat: X (fixes #{issue})"`
-7. Open a PR using the template
-8. Address validation feedback if needed
-9. Don't merge — wait for human approval
+## MVP rules
 
-### If You're a Human Reviewer
-1. Monitor PRs in the "In Review" state
-2. Review code against the original task spec
-3. Check for security/performance concerns
-4. Approve or request changes
-5. Once approved, merge to main
-6. GitHub Actions will handle cleanup and notifications
+- Do not work directly on `main` for task work
+- Use a task branch
+- Open a pull request for changes
+- Merge only after human review
+- Keep changes inside the task scope
 
-### If You're Base44 / Orchestration UI
-1. Read GitHub Issues and PRs via the API
-2. Display the current state in your dashboard
-3. Receive webhook notifications on task completion
-4. Never commit code or merge PRs
-5. Always respect GitHub as source of truth
+## Scope note
 
-## Important Conventions
+This repository is MVP-only.
 
-### Branching
-```
-feature/task-{issue-id}-{slug}
-
-Example: feature/task-42-auth-service
-```
-- Always create a branch per issue
-- Never work directly on main/develop
-- Branch is auto-created when task is marked `assigned/cursor`
-
-### Commit Messages
-```
-feat: brief description (fixes #{issue})
-```
-Include the issue reference so commits are linked.
-
-### Pull Requests
-- Use the PR template (auto-filled)
-- Link to the issue with `Closes #XXX`
-- List what changed and how to test
-- Check the success criteria from the original issue
-- Don't merge yourself — wait for approval
-
-### Labels
-| What | Label |
-|------|-------|
-| Task ready to implement | `status/todo` `assigned/cursor` |
-| Someone is working on it | `status/in-progress` |
-| PR waiting for review | `status/review` |
-| Task is complete | `status/done` |
-
-## Handling Problems
-
-### Issue Spec Is Unclear
-- **Don't** assume what you need to do
-- **Do** comment on the issue with specific questions
-- **Do** wait for OpenAI's response before coding
-
-### Test Validation Fails
-- GitHub Action comments on your PR with the error
-- Fix the issue locally
-- Push again — tests re-run automatically
-
-### PR Has Merge Conflicts
-- Rebase: `git fetch origin main && git rebase origin/main`
-- Resolve conflicts locally
-- Force push: `git push --force-with-lease`
-
-### Code Review Asks for Changes
-- Make requested changes
-- Commit and push to same branch
-- GitHub Auto-updates the PR
-- Request re-review when ready
-
-## Questions?
-
-- Check [docs/WORKFLOW.md](docs/WORKFLOW.md) for step-by-step guides
-- Check [SYSTEM_ROLES.md](SYSTEM_ROLES.md) for role clarifications
-- Comment on relevant GitHub Issue with your question
-- Tag @openai or @base44 if seeking specific input
-
-## Code of Conduct
-
-All participants agree to:
-- Respect task spec boundaries (don't improvise features beyond spec)
-- Respect role boundaries (don't merge your own PRs, don't commit as another role)
-- Be responsive (answer clarifying questions quickly)
-- Keep GitHub as single source of truth (no ad-hoc decisions)
-
----
-
-**Happy orchestrating! 🎼**
+It does not include MCP, webhooks, or advanced automation.

--- a/README.md
+++ b/README.md
@@ -195,3 +195,22 @@ See LICENSE file (or add your own).
 
 **Last Updated:** 2026-03-19  
 **Status:** MVP Phase — Ready for human-in-the-loop operations
+## MVP responsibilities
+
+At the current MVP stage:
+
+- **GitHub** is the source of truth.
+- **OpenAI / ChatGPT** acts as the director and task spec author.
+- **Cursor** acts as the executor for repository and documentation changes.
+- **Base44** is used for visualization and drafting only.
+- **Humans** review pull requests and approve merges.
+
+## MVP scope
+
+This repository currently supports a manual MVP workflow:
+- Issues define tasks
+- Task branches implement work
+- Pull requests deliver changes
+- Humans review and merge
+
+No MCP, no webhooks, and no advanced automation are part of this MVP repository.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -364,4 +364,10 @@ For MVP operation:
 - Never create commits directly on `main` for task work.
 - All task work must be delivered through a pull request.
 - No pull request should be merged without human review/approval.
-- A pull request should be merged only when the issue’s Success Criteria and Definition of Done are satisfied.
+- A pull request should be merged only when the issue’s Success Criteria and Definition of Done are satisfied.### MVP branch creation
+For the current MVP, task branches are created manually from `main` using the agreed naming format:
+
+`orchestrator/ORCH-xxxx-description`
+
+### Base44 role in MVP
+Base44 is used for visualization and drafting only in the current MVP. It does not act as the source of truth and does not perform repository changes directly.


### PR DESCRIPTION
## Task
- **Task ID:** ORCH-0006
- **Links:** Fixes #9

## Summary
This PR aligns MVP documentation across:
- README.md
- docs/WORKFLOW.md
- CONTRIBUTING.md

It ensures consistency with the current MVP reality:
- GitHub is the source of truth
- Work happens via Issues → branches → PRs → human merge
- Base44 is visualization-only
- Cursor is executor
- OpenAI is director
- No MCP, no webhooks, no advanced automation

## How to verify
- Open README.md, docs/WORKFLOW.md, CONTRIBUTING.md
- Confirm all three describe the same MVP workflow and roles

## Checklist
- [ ] Documentation aligned across all files
- [ ] MVP-only scope maintained