### PR TITLE
docs(ORCH-0007): enforce MVP discipline and PR hygiene

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -370,4 +370,12 @@ For the current MVP, task branches are created manually from `main` using the ag
 `orchestrator/ORCH-xxxx-description`
 
 ### Base44 role in MVP
-Base44 is used for visualization and drafting only in the current MVP. It does not act as the source of truth and does not perform repository changes directly.
+Base44 is used for visualization and drafting only in the current MVP. It does not act as the source of truth and does not perform repository changes directly.## 11. MVP discipline and PR hygiene
+
+For the current MVP:
+
+- No task work should happen directly on `main`.
+- All changes must be delivered through a pull request.
+- Pull request descriptions should follow the repository’s expected PR structure consistently.
+- Pull requests should link back to the originating issue, for example `Fixes #...` or `Closes #...`.
+- Task specifications should be created using the task-spec issue template so the expected routing fields are present.


### PR DESCRIPTION
## Task
- **Task ID:** ORCH-0007
- **Links:** Fixes #11

## Summary
This PR makes a small MVP documentation-only update to `docs/WORKFLOW.md` to enforce workflow discipline and PR hygiene:
- No task work happens directly on `main`
- All changes are delivered via PRs
- PR descriptions must follow the repository’s PR template sections consistently
- PRs must link back to the originating issue
- Task specifications must be created using the task-spec issue template

No MCP, webhooks, GitHub Actions, or advanced automation is introduced.

### What Changed
- Added an MVP discipline and PR hygiene section to `docs/WORKFLOW.md`

### How to Test
1. Open `docs/WORKFLOW.md`
2. Confirm the new subsection exists
3. Confirm it includes:
   - no direct task work on `main`
   - PR required for all changes
   - PR description structure expected
   - issue linking expected
   - task-spec issue template expected

### Validation Checklist
- [x] Documentation change matches ORCH-0007 requirements
- [x] No MCP/webhook/automation content added
- [x] MVP-only scope maintained