### PR TITLE
docs(ORCH-0008): improve task spec template clarity and consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-spec.md
+++ b/.github/ISSUE_TEMPLATE/task-spec.md
@@ -43,3 +43,20 @@ Relates to: #
 - Created by: OpenAI
 - Status: Awaiting Implementation
 - Last updated: (auto)
+### Goal
+Describe the specific outcome this task should achieve.
+
+### Success Criteria
+List clear and testable results. A reviewer should be able to confirm each item.
+
+### Technical Context
+Include relevant files, paths, dependencies, or links needed to complete the task.
+
+### Constraints
+List what must NOT be done (no automation, no new tools, MVP-only limits).
+
+### Out of scope
+Clearly state what is NOT part of this task to avoid scope creep.
+
+### Notes for implementer
+Include any important sequencing, risks, or assumptions.


### PR DESCRIPTION
## Task
- **Task ID:** ORCH-0008
- **Links:** Fixes #13

## Summary
This PR makes a small clarity pass on `.github/ISSUE_TEMPLATE/task-spec.md` so future task specs are easier to execute consistently.

Changes are minimal and template-only:
- clearer Goal prompt
- testable Success Criteria guidance
- stronger Technical Context and Constraints guidance
- new Out of scope section to reduce ambiguity
- improved Notes for implementer guidance

### What Changed
- Improved the task spec template wording in `.github/ISSUE_TEMPLATE/task-spec.md`
- Made future task specs clearer, more structured, and less ambiguous

### How to Test
1. Open `.github/ISSUE_TEMPLATE/task-spec.md`
2. Start creating a new issue with the template
3. Confirm the template now prompts for:
   - specific outcomes
   - testable success criteria
   - explicit constraints
   - explicit out-of-scope boundaries
   - implementer notes

### Validation Checklist
- [x] Template remains MVP-only
- [x] No MCP/webhook/advanced automation added
- [x] Task spec clarity improved without adding process overhead